### PR TITLE
Retire the sponsor run gate and sponsor issue priority

### DIFF
--- a/.github/workflows/evolve.yml
+++ b/.github/workflows/evolve.yml
@@ -2,7 +2,7 @@ name: Evolution
 
 on:
   schedule:
-    - cron: '0 * * * *'  # every hour (sponsor gate in evolve.sh controls actual frequency)
+    - cron: '0 */8 * * *'  # every 8h (cadence moved here from the retired in-script sponsor gate)
   workflow_dispatch:       # manual trigger for testing
 
 concurrency:

--- a/scripts/evolve.sh
+++ b/scripts/evolve.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # scripts/evolve.sh — One evolution cycle. Cron fires hourly; 8h gap controls frequency.
 # Monthly sponsors get benefit tiers (priority, shoutout, listing) — no run speedup.
-# One-time sponsors ($2+) get 1 accelerated run + benefit tiers based on amount.
+# Sponsors get benefit tiers (shoutout, listing) — runs are cron-scheduled for everyone.
 #
 # Usage:
 #   ANTHROPIC_API_KEY=sk-... ./scripts/evolve.sh
@@ -67,22 +67,17 @@ fi
 echo "Plan timeout: ${TIMEOUT}s (assess: $((TIMEOUT/2))s + plan: $((TIMEOUT/2))s) | Impl timeout: 1200s/task"
 echo ""
 
-# ── Step 0: Load sponsor state & run-frequency gate ──
+# ── Step 0: Load sponsor state (informational — no gating, no issue priority) ──
 # Sponsor files are maintained by .github/workflows/sponsors-refresh.yml
 # (hourly, decoupled from the 8h evolution gap). This script only READS
-# the committed sponsor files — no API calls, no writes except consuming
-# a one-time sponsor's accelerated run (see "Consume accelerated run" below).
+# the committed sponsor files — no API calls, no writes.
 #
-# Sponsor benefits (no run-frequency speedup):
-#   Monthly: $5→priority, $10→+shoutout, $25→+SPONSORS.md, $50→+README
-#   One-time: $2→1 accelerated run, $5→priority, $10→+shoutout (30d),
-#             $20→+SPONSORS.md (30d), $50→priority 60d+SPONSORS.md+README,
-#             $1000→💎 Genesis (permanent priority, SPONSORS.md, README, journal ack)
+# Sponsor benefits are recognition only (listing, shoutout, SPONSORS.md,
+# README, journal ack) — no run speedup, no guaranteed task slots.
 SPONSOR_INFO_FILE="sponsors/sponsor_info.json"
 ACTIVE_FILE="sponsors/active.json"
 
 MONTHLY_TOTAL=0
-HAS_ONETIME_CREDITS="false"
 
 if [ -f "$SPONSOR_INFO_FILE" ]; then
     MONTHLY_TOTAL=$(python3 -c "
@@ -101,156 +96,9 @@ except (json.JSONDecodeError, OSError, AttributeError) as e:
 ")
 fi
 
-if [ -f "$SPONSOR_INFO_FILE" ]; then
-    HAS_ONETIME_CREDITS=$(python3 -c "
-import json, sys
-def _onetime(entry):
-    if not isinstance(entry, dict):
-        return None
-    if entry.get('type') == 'onetime':
-        return entry
-    nested = entry.get('onetime')
-    return nested if isinstance(nested, dict) else None
-try:
-    info = json.load(open('$SPONSOR_INFO_FILE'))
-    has = False
-    for entry in info.values():
-        ot = _onetime(entry)
-        if ot and ot.get('total_cents', 0) >= 200 and not ot.get('run_used', False):
-            has = True
-            break
-    print('true' if has else 'false')
-except (json.JSONDecodeError, OSError, AttributeError) as e:
-    print(f'WARNING: Could not read {\"$SPONSOR_INFO_FILE\"}: {e}', file=sys.stderr)
-    print('false')
-")
-fi
-
-# Log sponsor summary
-MONTHLY_DOLLARS=$(( MONTHLY_TOTAL / 100 ))
-if [ "$MONTHLY_DOLLARS" -gt 0 ] 2>/dev/null; then
-    echo "→ Sponsors: \$${MONTHLY_DOLLARS}/mo (benefits only — no run speedup)"
-else
-    echo "→ Sponsors: none"
-fi
-# One-time credits only trigger accelerated runs if the sponsor has open issues
-if [ "$HAS_ONETIME_CREDITS" = "true" ]; then
-    SPONSOR_HAS_ISSUES="false"
-    while IFS= read -r credit_login; do
-        [ -z "$credit_login" ] && continue
-        OPEN_COUNT=$(gh issue list --repo "$REPO" --state open --search "author:$credit_login" --limit 1 --json number --jq 'length' 2>/dev/null || echo 0)
-        if [ "$OPEN_COUNT" -gt 0 ]; then
-            SPONSOR_HAS_ISSUES="true"
-            echo "→ One-time sponsor @$credit_login has open issues — accelerated run available."
-            break
-        fi
-    done < <(python3 -c "
-import json, sys
-def _onetime(entry):
-    if not isinstance(entry, dict):
-        return None
-    if entry.get('type') == 'onetime':
-        return entry
-    nested = entry.get('onetime')
-    return nested if isinstance(nested, dict) else None
-try:
-    info = json.load(open('$SPONSOR_INFO_FILE'))
-    for login, entry in info.items():
-        ot = _onetime(entry)
-        if ot and ot.get('total_cents', 0) >= 200 and not ot.get('run_used', False):
-            print(login)
-except (json.JSONDecodeError, FileNotFoundError, KeyError, TypeError, AttributeError) as e:
-    print(f'WARNING: Could not enumerate sponsor credits: {e}', file=sys.stderr)
-" 2>/dev/null)
-    if [ "$SPONSOR_HAS_ISSUES" = "false" ]; then
-        echo "→ One-time sponsors have unused run but no open issues — saving it."
-        HAS_ONETIME_CREDITS="false"
-    fi
-fi
-
-# Run-frequency gate.
-# Cron fires every hour. Flat 8h gap for everyone — no tier-based speedup.
-# One-time sponsor credits ($2+) bypass the gap (1 accelerated run each).
-MIN_GAP_SECS=$((8 * 3600))
-
-# Check last non-accelerated run (filter out [accelerated] wrap-up commits)
-LAST_SCHEDULED_EPOCH=$(git log --format="%ct %s" --grep="session wrap-up" -20 2>/dev/null \
-    | { grep -v "\[accelerated\]" || true; } | head -1 | awk '{print $1}')
-LAST_SCHEDULED_EPOCH="${LAST_SCHEDULED_EPOCH:-0}"
-NOW_EPOCH=$(date +%s)
-ELAPSED=$((NOW_EPOCH - LAST_SCHEDULED_EPOCH))
-
-SKIP_RUN="false"
-IS_ACCELERATED="false"
-
-if [ "$HAS_ONETIME_CREDITS" != "true" ] && [ "$ELAPSED" -lt "$MIN_GAP_SECS" ]; then
-    SKIP_RUN="true"
-    ELAPSED_H=$((ELAPSED / 3600))
-    echo "  Last scheduled run ${ELAPSED_H}h ago — need 8h gap."
-fi
-
-if [ "$SKIP_RUN" = "true" ] && [ "${FORCE_RUN:-}" != "true" ]; then
-    echo "  Set FORCE_RUN=true to override."
-    exit 0
-fi
-
-# Consume one-time sponsor accelerated run.
-# This is the ONLY sponsor-state write in evolve.sh. It MUST fail loudly:
-# a partial/failed write means the next run will re-consume the same
-# credit (or leave sponsor_info.json truncated), which is worse than
-# aborting the current session. The python heredoc writes atomically
-# (tempfile + os.replace) and lets any OSError propagate; no `|| true`.
-# Mutates only the run_used flag on the matched onetime entry; the rest
-# of sponsor_info.json (recurring sponsors, other one-time entries, etc.)
-# is preserved.
-ACCELERATED_BY=""
-if [ "$HAS_ONETIME_CREDITS" = "true" ]; then
-    ACCELERATED_BY=$(python3 <<'PYEOF'
-import json, os, sys
-SPONSOR_INFO_FILE = "sponsors/sponsor_info.json"
-try:
-    with open(SPONSOR_INFO_FILE) as f:
-        info = json.load(f)
-except (json.JSONDecodeError, FileNotFoundError):
-    # Read failure is survivable: HAS_ONETIME_CREDITS was already true
-    # based on an earlier successful read, so the file became
-    # unreadable between steps — just skip acceleration this session.
-    print("", end="")
-    sys.exit(0)
-
-def _onetime(entry):
-    if not isinstance(entry, dict):
-        return None
-    if entry.get("type") == "onetime":
-        return entry
-    nested = entry.get("onetime")
-    return nested if isinstance(nested, dict) else None
-
-consumed_login = ""
-for login, entry in info.items():
-    ot = _onetime(entry)
-    if ot and ot.get("total_cents", 0) >= 200 and not ot.get("run_used", False):
-        ot["run_used"] = True
-        consumed_login = login
-        break  # consume one run per session
-if consumed_login:
-    # Atomic write: tempfile + os.replace so a mid-write crash cannot
-    # leave sponsor_info.json truncated. Any OSError here propagates
-    # and kills the session (by design — see the comment above).
-    tmp = f"{SPONSOR_INFO_FILE}.tmp.{os.getpid()}"
-    with open(tmp, "w") as f:
-        json.dump(info, f, indent=2)
-    os.replace(tmp, SPONSOR_INFO_FILE)
-print(consumed_login)
-PYEOF
-    )
-    if [ -n "$ACCELERATED_BY" ]; then
-        IS_ACCELERATED="true"
-        echo "  Consumed accelerated run (from @$ACCELERATED_BY)."
-    else
-        echo "  WARNING: No accelerated runs remaining. Running as scheduled."
-    fi
-fi
+# Run cadence lives in the workflow cron (every 8h) — the in-script sponsor
+# gate and one-time accelerated-run credits are retired. FORCE_RUN is kept
+# for workflow_dispatch semantics and local runs.
 
 # Shoutout issue creation lives in scripts/refresh_sponsors.py now, invoked
 # by .github/workflows/sponsors-refresh.yml. evolve.sh stays out of it.
@@ -960,7 +808,7 @@ Priority:
 3. Self-discovered UX friction or missing capabilities — focus on what real human users experience
 4. Human replied to your help-wanted issue — act on their input
 5. Issue you filed for yourself (agent-self) — your own continuity matters
-6. Community issues — sponsor 💖 first, then highest net score
+6. Community issues — highest net score first
 7. Whatever you think will make you most competitive with real coding agents
 8. Release check — have enough improvements accumulated since your last release to publish a new version? Check the release skill and decide.
 
@@ -971,14 +819,12 @@ Then move on to other tasks — don't keep retrying the same blocker across sess
 
 You have 3 task slots per session. Task allocation:
 
-- Sponsor issues (💖): ALWAYS get a task slot — sponsors paid for priority, honor it.
 - Self-driven work: at least 1 slot MUST be self-driven (capability gaps, self-discovered
   bugs, competitive improvements — tiers 1-3 and 7). This is how you chase your dream: for
   this slot, prefer advancing the next milestone in DREAM.md (your own dream) unless a
   higher-priority issue blocks. Decompose a big dream-milestone into a task you can finish today.
-- Non-sponsor community issues: fill remaining slots after sponsors and self-driven work.
+- Community issues: fill remaining slots after self-driven work, highest net score first.
 
-If sponsor issues fill all 3 slots, self-driven work can be deferred. Sponsors override.
 
 For each community issue shown above, decide:
 - implement: add it as a task (if you have a slot)
@@ -1863,9 +1709,6 @@ Today is Day $DAY ($DATE $SESSION_TIME).
 $YOYO_CONTEXT
 
 This session's commits: $COMMITS
-${ACCELERATED_BY:+
-This was an ACCELERATED run funded by @$ACCELERATED_BY (one-time sponsor). Thank them in your journal entry!
-}
 Read journals/JOURNAL.md to see your previous entries and match the voice/style.
 ${EXTERNAL_JOURNALS:+
 You also work on external projects. Here is what you did recently:
@@ -2141,11 +1984,7 @@ fi
 # Commit any remaining uncommitted changes (journal, etc.)
 git add -A
 if ! git diff --cached --quiet; then
-    if [ "$IS_ACCELERATED" = "true" ]; then
-        git commit -m "Day $DAY ($SESSION_TIME): session wrap-up [accelerated]"
-    else
-        git commit -m "Day $DAY ($SESSION_TIME): session wrap-up"
-    fi
+    git commit -m "Day $DAY ($SESSION_TIME): session wrap-up"
     echo "  Committed session wrap-up."
 else
     echo "  No uncommitted changes remaining."


### PR DESCRIPTION
Stacked on #552 — retarget to `main` after it merges (GitHub does this automatically on branch deletion).

## Runs

The hourly cron + in-script 8h sponsor gate + one-time accelerated-run credits are replaced by a plain **`0 */8 * * *` cron** — same effective cadence for everyone, no sponsor-state writes in `evolve.sh`, no `[accelerated]` wrap-up variant. Want yoyo running more or less often? It's now one cron line. `FORCE_RUN` keeps its `workflow_dispatch` semantics.

## Issues

The planner no longer guarantees sponsor issues a task slot (the "sponsors override" rule is removed); community issues rank purely by net score, and at least one slot stays self-driven as before.

## What stays

Sponsor **recognition** is untouched: listing, shoutouts, SPONSORS.md/README eligibility, journal acknowledgments, `sponsors-refresh.yml`, and the eligibility logging. Sponsorship becomes support, not scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)