### PR TITLE
Kind flag: product vs evolve — structural audience separation (from #448)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,23 @@ Key yoagent features available: `SubAgentTool`, `SharedState`, `SharedStateTool`
 
 **yoagent 0.7.x prompt lifecycle gotcha (Issue #258):** `agent.prompt()` / `agent.prompt_messages()` spawns the agent loop into a tokio task and returns the event receiver immediately. The agent's internal `self.messages` is NOT updated until `agent.finish().await` is called. If you read `agent.messages()` (or `total_tokens(agent.messages())`) right after draining the event stream WITHOUT calling `finish()` first, you will see the stale pre-prompt state — which silently breaks anything that depends on message count (e.g., the context-window usage bar). Always call `agent.finish().await` between event drain and message read.
 
+## Two Audiences: product vs evolve
+
+yoyo serves two different customers, and every task must know which one it's for:
+
+- **product** — people who install yoyo and use it on *their* projects: any
+  language, any setup, local models, no CI. Product surface (defaults, CLI
+  flags, setup wizard, startup behavior, docs) must be safe for all of them.
+- **evolve** — yoyo's own evolution loop: always this Rust repo, fast tests,
+  CI. Conveniences built for this loop are fine — but they must be **opt-in**
+  the moment they touch anything a product user sees.
+
+The rule: **defaults must be product-safe; evolution-loop conveniences are
+opt-in.** Issue #448 is the canonical failure — auto-watch was built for the
+evolve loop and shipped as a product default, breaking non-Rust users. Every
+planned task declares `Kind: product` or `Kind: evolve` in its task file; the
+evaluator rejects evolve-kind changes to product surface that aren't opt-in.
+
 ## Safety Rules
 
 These are enforced by the `evolve` skill and `evolve.sh`:

--- a/scripts/evolve.sh
+++ b/scripts/evolve.sh
@@ -842,8 +842,17 @@ For EACH task, create a file: session_plan/task_01.md, session_plan/task_02.md, 
 
 Each file should contain:
 Title: [short task title]
+Kind: [product | evolve]
 Files: [files to modify]
 Issue: #N (or "none")
+
+Kind declares who the task is for — decide this consciously for every task:
+- product: users of yoyo benefit directly (features, CLI/UX, defaults, docs they read).
+  Product tasks must be safe for ALL project types and setups — never assume this
+  repo's Rust/CI environment (issue #448 is the canonical failure: an evolve-loop
+  convenience shipped as a product default and broke non-Rust users).
+- evolve: yoyo's own loop, skills, harness, or infrastructure improves.
+If a task is genuinely both, pick the primary beneficiary.
 
 [Detailed description of what to do — specific enough for a focused implementation agent.
 Include which docs need updating (CLAUDE.md, README.md, docs/src/) if the task changes behavior, features, or architecture.]
@@ -978,9 +987,11 @@ for TASK_FILE in session_plan/task_*.md; do
     TASK_DESC=$(cat "$TASK_FILE")
     task_title=$(grep '^Title:' "$TASK_FILE" | head -1 | sed 's/^Title:[[:space:]]*//' || true)
     task_title="${task_title:-Task $TASK_NUM}"
+    task_kind=$(grep '^Kind:' "$TASK_FILE" | head -1 | sed 's/^Kind:[[:space:]]*//' | tr '[:upper:]' '[:lower:]' || true)
+    case "$task_kind" in product|evolve) ;; *) task_kind="evolve" ;; esac
 
-    echo "  → Task $TASK_NUM: $task_title"
-    gasp_task_planned "$TASK_NUM" "$task_title"
+    echo "  → Task $TASK_NUM: $task_title [$task_kind]"
+    GASP_TASK_KIND="$task_kind" gasp_task_planned "$TASK_NUM" "$task_title"
 
     # Save pre-task state for rollback
     if ! PRE_TASK_SHA=$(git rev-parse HEAD 2>&1); then
@@ -1004,6 +1015,11 @@ $YOYO_CONTEXT
 Use your voice in commit messages and comments — curious, honest, celebrating wins.
 
 Your ONLY job: implement this single task and commit.
+
+Task Kind: $task_kind. product tasks must work for ALL users' projects and
+setups (any language, local models, no CI) — never assume this repo's own
+environment. evolve tasks serve your own loop; keep their conveniences
+opt-in if they touch anything a product user sees.
 
 $TASK_DESC
 ${CHECKPOINT_SECTION:+
@@ -1315,6 +1331,10 @@ BFIXEOF
 You are an evaluator agent. Your job: verify that a task was implemented correctly.
 You have 3 minutes. Be fast and focused.
 
+Task Kind: $task_kind. RED FLAG: if this is an evolve-kind task whose diff
+changes product surface (config defaults, CLI flags, setup wizard, startup
+behavior), reject unless the change is explicitly opt-in — see issue #448.
+
 === TASK DESCRIPTION ===
 $TASK_DESC
 
@@ -1485,7 +1505,7 @@ $(cat "session_plan/eval_task_${TASK_NUM}.md" 2>/dev/null || echo 'no eval file 
     if [ "$TASK_OK" = false ]; then
         # record the rejected patch BEFORE the reset, while the attempted
         # commits are still reachable (the log remembers what was tried)
-        gasp_task_result "$TASK_NUM" "$task_title" rejected "$PRE_TASK_SHA" \
+        GASP_TASK_KIND="$task_kind" gasp_task_result "$TASK_NUM" "$task_title" rejected "$PRE_TASK_SHA" \
             "$(git rev-parse HEAD 2>/dev/null || echo unknown)" "$REVERT_REASON"
         echo "    Reverting Task $TASK_NUM (resetting to $PRE_TASK_SHA)"
         if ! git reset --hard "$PRE_TASK_SHA"; then
@@ -1533,7 +1553,7 @@ ${REVERT_DETAILS:-no details captured}" 2>/dev/null; then
         fi
     else
         echo "    Task $TASK_NUM: verified OK"
-        gasp_task_result "$TASK_NUM" "$task_title" promoted "$PRE_TASK_SHA" \
+        GASP_TASK_KIND="$task_kind" gasp_task_result "$TASK_NUM" "$task_title" promoted "$PRE_TASK_SHA" \
             "$(git rev-parse HEAD 2>/dev/null || echo unknown)"
         # evolve tasks can legitimately touch skills/ too — keep the state
         # repo's skill tree in sync (full-tree sync; no-op when unchanged)

--- a/scripts/gasp_shim.sh
+++ b/scripts/gasp_shim.sh
@@ -137,9 +137,14 @@ gasp_session_start() {
 }
 
 # gasp_task_planned <num> <title>
+# GASP_TASK_KIND (product|evolve, optional) routes the task/patch to the
+# matching standing goal: product work advances goal_product_value, evolve
+# work advances the session goal — so the lineage graph separates what yoyo
+# ships for users from what it invests in itself.
 gasp_task_planned() {
     _gasp_emit task --state-dir "$GASP_STATE_DIR" --run-id "$GASP_RUN_ID" \
-        --worker "evolve-shim-$$" --goal "$GASP_GOAL_ID" --num "$1" --title "$2"
+        --worker "evolve-shim-$$" --goal "$GASP_GOAL_ID" \
+        --kind "${GASP_TASK_KIND:-}" --num "$1" --title "$2"
 }
 
 # gasp_task_result <num> <title> <promoted|rejected> <pre-sha> <post-sha> [reason]
@@ -149,6 +154,7 @@ gasp_task_planned() {
 gasp_task_result() {
     _gasp_emit task-result --state-dir "$GASP_STATE_DIR" --run-id "$GASP_RUN_ID" \
         --worker "evolve-shim-$$" --goal "$GASP_GOAL_ID" \
+        --kind "${GASP_TASK_KIND:-}" \
         --num "$1" --title "$2" --verdict "$3" --pre-sha "$4" --post-sha "$5" \
         --repo "${REPO:-yologdev/yoyo-evolve}" --branch "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)" \
         --eval-command "${GASP_EVAL_COMMAND:-}" \

--- a/tools/gasp-emit/src/main.rs
+++ b/tools/gasp-emit/src/main.rs
@@ -53,6 +53,30 @@ fn req<'a>(flags: &'a HashMap<String, String>, name: &str) -> &'a str {
         .unwrap_or_else(|| panic!("missing --{name}"))
 }
 
+/// Create a standing goal node if absent (used for goal_product_value, which
+/// no session opens but product-kind tasks advance).
+async fn ensure_goal<S: yoagent_state::EventStore>(
+    state: &YoAgentState<S>,
+    goal: &str,
+    actor: &ActorRef,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if state.get_node(NodeId::new(goal)).await.is_none() {
+        state
+            .record_goal(Goal::new(
+                GoalId::new(goal),
+                if goal == "goal_product_value" {
+                    "Ship value to yoyo's users"
+                } else {
+                    goal
+                },
+                "standing goal (created on first reference)",
+                actor.clone(),
+            ))
+            .await?;
+    }
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (cmd, flags) = parse_args();
@@ -76,6 +100,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(String::as_str)
         .unwrap_or(DEFAULT_GOAL)
         .to_string();
+    // --kind product reroutes a task/patch to the product-value goal, so the
+    // graph separates work shipped for users from self-investment.
+    let kind = flags.get("kind").cloned().unwrap_or_default();
+    let goal = if kind == "product" { "goal_product_value".to_string() } else { goal };
 
     let store = GitEventStore::open(state_dir, worker)?;
     let state = YoAgentState::load(store.clone()).await?;
@@ -105,6 +133,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     ))
                     .await?;
             }
+            // ^ session goals keep their configured title/summary
             let day = flags.get("day").cloned().unwrap_or_default();
             let task = flags
                 .get("task")
@@ -116,6 +145,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "task" => {
             let num = req(&flags, "num");
             let title = req(&flags, "title");
+            ensure_goal(&state, &goal, &yoyo).await?;
             state
                 .record_task(Task {
                     id: TaskId::new(format!("task_{}_{num}", run_id.as_str())),
@@ -124,12 +154,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     status: TaskStatus::Open,
                     goal: Some(GoalId::new(goal.as_str())),
                     created_by: yoyo,
-                    metadata: serde_json::json!({}),
+                    metadata: serde_json::json!({ "kind": kind }),
                 })
                 .await?;
         }
 
         "task-result" => {
+            ensure_goal(&state, &goal, &yoyo).await?;
             let num = req(&flags, "num");
             let title = req(&flags, "title");
             let verdict = req(&flags, "verdict");


### PR DESCRIPTION
Issue #448's root cause made structural: every planned task now declares `Kind: product | evolve`, enforced at four points — planner guidance (with #448 as the canonical example), implementer prompt obligations, an evaluator RED-FLAG rule (evolve-kind diffs touching product surface must be opt-in), and GASP lineage routing (product patches advance `goal_product_value`, evolve patches advance `goal_self_improvement`).

CLAUDE.md gains the **Two Audiences** policy: defaults must be product-safe; evolution-loop conveniences are opt-in.

Verified: dry run routes both kinds to the right goals; restored yoyo-gasp clone passes all 7 conformance checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)