### PR TITLE
Bump yoagent 0.13 → 0.14 (0.14.2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "yoyo"
 path = "src/main.rs"
 
 [dependencies]
-yoagent = { version = "0.13", features = ["openapi"] }
+yoagent = { version = "0.14", features = ["openapi"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
One-line dependency bump: `Cargo.toml` `yoagent = "0.13"` → `"0.14"` (resolves 0.14.2).

## Why it's zero-source-change
- yoagent 0.14.0 and 0.14.1 both declare **"no API surface changed"**; 0.14.2 is docs/metadata only.
- Every surface yoyo depends on is **byte-identical** in 0.14.2 vs 0.13.x: `types.rs` (covering `StopReason`, `Content`, `ToolError`, `CacheConfig`, `Message`, `AgentMessage`, `Usage`) diffs empty; `agent.rs`, `context.rs`, `sub_agent.rs`, `provider/mod.rs`, `openapi.rs` unchanged.
- The two changelog behaviors are **no-ops for yoyo**: MCP is stdio-only (no `connect_http`), and yoyo never calls `prompt_structured`.

## Gains for free
- Accurate output-token accounting — a trailing `message_delta` no longer zeroes it (better cost / `ContextTracker`).
- yoagent **#89**: a turn whose tool arguments never assembled now fails loudly (`StopReason::Error`) instead of silently executing the tool with `{}`.

## Verification
- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` — all green locally; **CI green** on the PR.
- `cargo test`: 3 failures on the local **macOS** checkout (`directory_restrictions` `/etc`→`/private/etc` symlink; `generate_tips` cwd-race under parallel run) are **pre-existing** — they reproduce identically on 0.13.3 and are yoagent-independent.
- An independent adversarial review diffed 0.13.3 vs 0.14.2 crate-to-crate and confirmed no compile break, no reachable behavioral regression, and no invalidated 0.13 assumption. (`pause_turn`→`Error` is unreachable — yoyo registers no Anthropic server-side tools.)

## Follow-up (not in this PR)
Behavioral hardening for the newly-reachable `StopReason::Error` path (#89's fail-loud turn is currently surfaced on screen but swallowed for control flow) is routed to yoyo as issue #646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)